### PR TITLE
Answer to issue 6: add a splitter, then scale up to 6 states

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,7 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
+
   message(sprintf('  Retrieving data for %s-%s', state, site_info$site_no))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/_targets.R
+++ b/_targets.R
@@ -12,7 +12,7 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL')
+states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
 parameter <- c('00060')
 
 # Targets
@@ -23,7 +23,8 @@ list(
   # Pull data for each state's oldest site
   tar_map(
     values = tibble(state_abb = states),
-    tar_target(nwis_data, get_site_data(oldest_active_sites, state_abb, parameter))
+    tar_target(nwis_inventory, filter(oldest_active_sites, state_cd == state_abb)),
+    tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter))
     # Insert step for tallying data here
     # Insert step for plotting data here
   ),


### PR DESCRIPTION
This splits the `oldest_active_sites` data by state _before_ it is passed to `get_site_data()` to prevent redownloads of each state's data when we add a new state.

When I added `IN` and `IA`, the pipeline rebuilt `oldest_active_sites`, all of the `nwis_inventory_*` targets and then `nwis_data_IA` and `nwis_data_IN`.